### PR TITLE
Dialogflow V1 to V2 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,13 @@ You might have noticed the conversation interface of BenTen. Benten uses [Dialog
 
 Let us set up your own dialog flow agent. Download the agent zip file from here [benten-agent](https://github.com/DivakarUngatla/divakarungatla.github.io/raw/master/benten/dialogflow-agent/benten-open-source.zip)
 
-Follow the instructions in this page [Create-BenTen-Agent-in-Dialog-flow](https://github.com/intuit/benten/wiki/Create-BenTen-Agent-in-Dialog-flow). 
+Follow the instructions in this page [Create-BenTen-Agent-in-Dialog-flow](https://github.com/intuit/benten/wiki/Create-BenTen-Agent-in-Dialog-flow) to create the agent.
 
-At the end of it you should have your own `dialog flow token`.
+Follow the instructions in this page [OAuth Setup For Dialogflow Agent](https://github.com/intuit/benten/wiki/OAuth-Setup-For-Dialogflow-Agent) to setup OAuth for the agent. 
+
+At the end of it you should have your own `dialogflow Project ID` with OAuth setup complete.
+
+**NOTE**: The dialogflow client in Benten will not work unless the OAuth setup is complete.
 
 Now open benten.properties
 
@@ -123,7 +127,7 @@ Now open benten.properties
 cd benten-starter
 vi src/main/resources/benten.properties
 ```
-In line #10 change the value of `benten.ai.token` with your token from above
+In line #10 change the value of `benten.ai.projectId` with your Project ID from above
 
 # Start BenTen
 ```sh

--- a/benten-common/pom.xml
+++ b/benten-common/pom.xml
@@ -18,6 +18,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>3.10.0</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>2.8.2</version>

--- a/benten-common/src/main/java/com/intuit/benten/common/nlp/BentenMessage.java
+++ b/benten-common/src/main/java/com/intuit/benten/common/nlp/BentenMessage.java
@@ -1,12 +1,16 @@
 package com.intuit.benten.common.nlp;
 
 import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+import com.google.protobuf.Value;
 import com.intuit.benten.common.channel.Channel;
 import com.intuit.benten.common.channel.ChannelInformation;
 import com.intuit.benten.common.constants.SlackConstants;
 import com.intuit.benten.common.helpers.BentenMessageHelper;
 
 import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * @author Divakar Ungatla
@@ -74,5 +78,18 @@ public class BentenMessage {
 
     public String toString(){
         return "action="+action+", user="+ BentenMessageHelper.getParameterAsString(parameters,SlackConstants.CURRENT_USER);
+    }
+
+    public void setParameterstoJsonElement(Set<Map.Entry<String,com.google.protobuf.Value>> entrySet) {
+            for (Map.Entry<String, Value> entry : entrySet) {
+                if (entry.getValue().getKindCase().getNumber() == Value.STRING_VALUE_FIELD_NUMBER) {
+                    this.parameters.put(entry.getKey(), new JsonPrimitive(entry.getValue().getStringValue()));
+                } else if (entry.getValue().getKindCase().getNumber() == Value.STRUCT_VALUE_FIELD_NUMBER) {
+                    this.parameters.put(entry.getKey(), new JsonPrimitive(String.valueOf(entry.getValue().getStructValue())));
+                }
+                else if (entry.getValue().getKindCase().getNumber() == Value.NUMBER_VALUE_FIELD_NUMBER) {
+                    this.parameters.put(entry.getKey(), new JsonPrimitive(String.valueOf(entry.getValue().getNumberValue())));
+                }
+            }
     }
 }

--- a/benten-core/pom.xml
+++ b/benten-core/pom.xml
@@ -36,9 +36,9 @@
             <version>${spring.version}</version>
         </dependency>
         <dependency>
-            <groupId>ai.api</groupId>
-            <artifactId>libai</artifactId>
-            <version>1.6.12</version>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-dialogflow</artifactId>
+            <version>0.114.0-alpha</version>
         </dependency>
         <dependency>
             <groupId>com.github.xuwei-k</groupId>

--- a/benten-core/src/main/java/com/intuit/benten/nlp/NlpClient.java
+++ b/benten-core/src/main/java/com/intuit/benten/nlp/NlpClient.java
@@ -1,13 +1,14 @@
 package com.intuit.benten.nlp;
 
 import com.intuit.benten.common.nlp.BentenMessage;
+import com.intuit.benten.exceptions.AiException;
 
 /**
  * @author Divakar Ungatla
  * @version 1.0
  */
 public interface NlpClient {
-    BentenMessage sendText(String text, String sessionId);
-    BentenMessage sendText(String text, String sessionId, boolean reset);
+    BentenMessage sendText(String text, String sessionId) throws AiException;
+    BentenMessage sendText(String text, String sessionId, boolean reset) throws AiException;
     boolean isActionable(String action);
 }

--- a/benten-core/src/main/java/com/intuit/benten/nlp/NlpClient.java
+++ b/benten-core/src/main/java/com/intuit/benten/nlp/NlpClient.java
@@ -1,14 +1,13 @@
 package com.intuit.benten.nlp;
 
 import com.intuit.benten.common.nlp.BentenMessage;
-import com.intuit.benten.exceptions.AiException;
 
 /**
  * @author Divakar Ungatla
  * @version 1.0
  */
 public interface NlpClient {
-    BentenMessage sendText(String text, String sessionId) throws AiException;
-    BentenMessage sendText(String text, String sessionId, boolean reset) throws AiException;
+    BentenMessage sendText(String text, String sessionId);
+    BentenMessage sendText(String text, String sessionId, boolean reset);
     boolean isActionable(String action);
 }

--- a/benten-core/src/main/java/com/intuit/benten/nlp/dialogflow/DialogFlowClient.java
+++ b/benten-core/src/main/java/com/intuit/benten/nlp/dialogflow/DialogFlowClient.java
@@ -8,6 +8,7 @@ import com.intuit.benten.properties.AiProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.io.IOException;
+import com.intuit.benten.exceptions.AiException;
 import java.util.HashMap;
 
 /**
@@ -24,12 +25,12 @@ public class DialogFlowClient implements NlpClient {
     }
 
     @Override
-    public BentenMessage sendText(String text, String sessionId) {
+    public BentenMessage sendText(String text, String sessionId) throws AiException{
         return sendText(text,sessionId,false);
     }
 
     @Override
-    public BentenMessage sendText(String text, String sessionId, boolean reset) {
+    public BentenMessage sendText(String text, String sessionId, boolean reset) throws AiException{
 
         SessionsClient sessionsClient = null;
         try {

--- a/benten-core/src/main/java/com/intuit/benten/nlp/dialogflow/DialogFlowClient.java
+++ b/benten-core/src/main/java/com/intuit/benten/nlp/dialogflow/DialogFlowClient.java
@@ -19,9 +19,15 @@ import java.util.HashMap;
 public class DialogFlowClient implements NlpClient {
 
     private String PROJECT_ID;
+    SessionsClient sessionsClient;
 
     public DialogFlowClient(String PROJECT_ID) {
         this.PROJECT_ID = PROJECT_ID;
+        try {
+            sessionsClient = SessionsClient.create();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
 
     @Override
@@ -30,15 +36,8 @@ public class DialogFlowClient implements NlpClient {
     }
 
     @Override
-    public BentenMessage sendText(String text, String sessionId, boolean reset) throws AiException{
-
-        SessionsClient sessionsClient = null;
-        try {
-            sessionsClient = SessionsClient.create();
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-        SessionName session = SessionName.of(PROJECT_ID, sessionId);
+    public BentenMessage sendText(String text, String sessionId, boolean reset) throws AiException {
+            SessionName session = SessionName.of(PROJECT_ID, sessionId);
             BentenMessage bentenMessage;
 
             Builder textInput = TextInput.newBuilder().setText(text).setLanguageCode("en-US");

--- a/benten-core/src/main/java/com/intuit/benten/properties/AiProperties.java
+++ b/benten-core/src/main/java/com/intuit/benten/properties/AiProperties.java
@@ -13,14 +13,10 @@ import org.springframework.stereotype.Component;
 @PropertySource(value = "classpath:benten.properties")
 public class AiProperties {
 
-    private String token;
+    private String projectId;
 
-    public String getToken() {
-        return token;
-    }
+    public String getProjectId() { return projectId; }
 
-    public void setToken(String token) {
-        this.token = token;
-    }
+    public void setProjectId(String projectId) { this.projectId = projectId; }
 
 }

--- a/benten-core/src/main/resources/benten.properties
+++ b/benten-core/src/main/resources/benten.properties
@@ -5,7 +5,7 @@
 #benten.proxy.protocol=http
 
 #benten ai configuration
-benten.ai.token=<dialog flow token>
+benten.ai.projectId=<dialogflow-project-id>
 
 #benten slack configuration
 benten.slack.token=<slack token>

--- a/benten-core/src/test/java/com/intuit/benten/ai/dialogflow/DialogFlowClientTest.java
+++ b/benten-core/src/test/java/com/intuit/benten/ai/dialogflow/DialogFlowClientTest.java
@@ -27,7 +27,7 @@ public class DialogFlowClientTest {
 
     @Before
     public void setup() {
-        nlpClient = new DialogFlowClient("89a1e02eacac4aa09646c93f5410e72f",bentenProxyConfig);
+        nlpClient = new DialogFlowClient("project-id");
     }
 
     @Test

--- a/benten-starter/pom.xml
+++ b/benten-starter/pom.xml
@@ -22,6 +22,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>28.1-jre</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
         </dependency>

--- a/benten-starter/src/main/java/BentenStarterApplication.java
+++ b/benten-starter/src/main/java/BentenStarterApplication.java
@@ -23,15 +23,12 @@ public class BentenStarterApplication extends SpringBootServletInitializer {
     AiProperties aiProperties;
 
     @Autowired
-    BentenProxyConfig bentenProxyConfig;
-
-    @Autowired
     MockFeatureServerRunner mockFeatureServerRunner;
 
     @Bean
     public NlpClient aiClient(){
 
-        return new DialogFlowClient(aiProperties.getToken(),bentenProxyConfig);
+        return new DialogFlowClient(aiProperties.getProjectId());
     }
 
     @PostConstruct

--- a/benten-starter/src/main/resources/benten.properties
+++ b/benten-starter/src/main/resources/benten.properties
@@ -7,7 +7,7 @@
 #benten.proxy.protocol=http
 
 #benten ai configuration
-benten.ai.token=<dialog flow token>
+benten.ai.projectId=<dialogflow-project-id>
 
 #benten slack configuration
 benten.slack.token=<slack token>


### PR DESCRIPTION
To be considered:

1. Session context reset hasn't been handled. Preliminary tests with karate mocks work fine. Need to figure out a way to set/delete session contexts like in v1 client. 
2. V2 agent supports only OAuth. Thus dialogflow token will have to be replaced by project-id and OAuth setup has to be done for agent. Refer [https://dialogflow.com/docs/reference/v2-auth-setup](here). TODO: Readme update.